### PR TITLE
Ensure we read read_csv inputs as literal data

### DIFF
--- a/vignettes/run-praat.Rmd
+++ b/vignettes/run-praat.Rmd
@@ -95,14 +95,14 @@ Of course, you can redirect the captured output using the pipe `%>%`, for exampl
 library(tidyverse)
 # Output to R tibble
 formants <- praat_run(script, capture = TRUE) %>%
-  read_csv()
+  read_csv(I(.))
 class(formants)
 glimpse(formants)
 ```
 
 ```{r echo=FALSE}
 # Need this because code is not run in the vignette, since it relies on external software (Praat).
-f_tbl <- read_csv(formants)
+f_tbl <- read_csv(I(formants))
 class(f_tbl)
 glimpse(f_tbl)
 ```
@@ -121,7 +121,7 @@ unit = "Bark"
 window = 0.02
 
 f_bark <- praat_run(script, unit, window, capture = TRUE) %>%
-  read_csv()
+  read_csv(I(.))
 attr(f_bark, "args") <- list(unit = unit, window = window)
 ```
 


### PR DESCRIPTION
In readr 2.0.0 you now need to specify literal data with `I()`, to
disambiguate it from a vector of filenames.